### PR TITLE
Update Graphviz.java

### DIFF
--- a/src/main/java/org/graphper/api/Graphviz.java
+++ b/src/main/java/org/graphper/api/Graphviz.java
@@ -18,6 +18,7 @@ package org.graphper.api;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -151,7 +152,7 @@ public class Graphviz extends GraphContainer implements Serializable {
       synchronized (this) {
         this.svg = null;
       }
-      return new String(resource.bytes());
+      return new String(resource.bytes(), StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new ExecuteException(e);
     }


### PR DESCRIPTION
SvgDrawBoard.graphResource() generates UTF-8 encoded  binary data, while Graphviz.toSvgStr() did not specify a charset and therefore used the system charset, which might destroy non US-ASCII characters.

thanks for your great work!