### PR TITLE
Lazily load fonts in AbstractFontSelector

### DIFF
--- a/core/src/main/java/org/graphper/layout/AbstractFontSelector.java
+++ b/core/src/main/java/org/graphper/layout/AbstractFontSelector.java
@@ -40,9 +40,18 @@ public abstract class AbstractFontSelector implements FontSelector {
   private LinkedHashSet<String> allAvailableFonts;
 
   protected AbstractFontSelector() {
-    initFontComparator();
-    Asserts.nullArgument(fontOrder, "Cannot found font comparator");
-    initDefaultFont();
+    // moved to #possiblyLoad()
+  }
+  
+  private boolean loaded = false;
+  
+  protected void possiblyLoad() {
+    if (loaded == false) {
+      initFontComparator();
+      Asserts.nullArgument(fontOrder, "Cannot found font comparator");
+      initDefaultFont();
+      loaded = true;
+    }
   }
 
   /**
@@ -62,6 +71,7 @@ public abstract class AbstractFontSelector implements FontSelector {
    */
   @Override
   public String defaultFont() {
+   possiblyLoad();
    return defaultFont;
   }
 
@@ -73,6 +83,7 @@ public abstract class AbstractFontSelector implements FontSelector {
    */
   @Override
   public boolean exists(String fontName) {
+    possiblyLoad();
     if (Objects.isNull(fontName)) {
       return false;
     }
@@ -82,6 +93,7 @@ public abstract class AbstractFontSelector implements FontSelector {
 
   @Override
   public String findFirstSupportFont(char c) {
+    possiblyLoad();
     for (String font : allAvailableFonts) {
       if (fontSupport(font, c)) {
         return font;


### PR DESCRIPTION
Hello! Thank you so much for this great library. I've been trying to debug an issue that only occurs on Macs and I think I've come up with a solution.

For my application I am using lwjgl (via libgdx), and if the user is running on Mac, trying to do anything in AWT-land while we're rendering on the main thread is dangerous. I don't know why but it seems entering AWT messes up environment variables or handles or who knows.

I've found that, if in the main thread, I just call:

```java
Graphviz.digraph();
```

There are no exceptions thrown or log messages printed anywhere, but it seems to poison the main render thread. I get all sorts of failures down the line trying to create Framebuffers (again, in lwjgl land):

```
Caused by: java.lang.IllegalStateException: Frame buffer couldn't be constructed: unknown error 0
	at com.badlogic.gdx.graphics.glutils.GLFrameBuffer.build(GLFrameBuffer.java:264)
	at com.badlogic.gdx.graphics.glutils.FrameBuffer.<init>(FrameBuffer.java:76)
	at com.badlogic.gdx.graphics.glutils.FrameBuffer.<init>(FrameBuffer.java:58)
	at org.jevon.gdx.ui.buffer.ScrollableBufferedTexture.drawResultToBufferedTexture(ScrollableBufferedTexture.java:286)
	... 13 more
```

Upon further investigation I have a feeling it is from the constructor in `AbstractFontSelector`:

```java
  protected AbstractFontSelector() {
    initFontComparator();
    Asserts.nullArgument(fontOrder, "Cannot found font comparator");
    initDefaultFont();
  }
```

Since `AWTMeasureText` extends `AbstractFontSelector`, it calls `initDefaultFont()` in the default no-arg constructor during service discovery, which calls `listAllSystemFonts()`, which then calls `GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()` - entering AWT space and causing all sorts of issues down the line.

In this commit, I've made the font loading for `AbstractFontSelector` lazy, so that it only tries to enter AWT land once it's evaluated all of the `MeasureText` services and considered their `order()`. (I'm providing my own `MeasureText` service that has a more important order than the built-in services.)

Not sure if this is a good solution, but it seems to be working well on my side so far. 🤞